### PR TITLE
Upgrade to registry 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry:2.6.2
+FROM registry:2.7.1
 
 LABEL org.label-schema.vendor="Indix" \
     org.label-schema.name="registry-s3" \


### PR DESCRIPTION
Hopefully this fixes a few weird errors we've been seeing with running an insecure registry.